### PR TITLE
Feat: Adding timestamp-based report expiration feature 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ constructor(
     address verifierProxy_,
     bytes32 _feedId,
     uint8   _decimals,
+    uint32  _maxReportExpirationSeconds,
     string  memory _description
 )
 ```
@@ -86,9 +87,16 @@ Fill in:
 2. `_feedId` – 32-byte identifier of the stream you want to mirror (e.g. ETH/USD).  
    Example: `0x000359843a543ee2fe414dc14c7e7920ef10f4372990b79d6361cdc0dd1ba782`.
 3. `_decimals` – usually **18**.
-4. `_description` – human-readable label, e.g. "ETH / USD Feed".
+4. `_maxReportExpirationSeconds` – the maximum allowed window between a report's observation time and its `expiresAt`.
+   - If a report's `expiresAt` is greater than `observationsTimestamp + _maxReportExpirationSeconds`, the update will revert.
+   - Example deploy scripts default to `30 days`, but you should set this to what makes sense for your deployment.
+5. `_description` – human-readable label, e.g. "ETH / USD Feed".
 
-Edit `script/DeployDataStreamsFeed.s.sol` with your values, **or** pass them as CLI arguments (see below).
+Edit the deploy scripts with your values, **or** pass them as CLI arguments (see below).
+
+Where to set the expiration window in scripts:
+- `script/DeployDataStreamsFeed.s.sol`: `uint32 maxExpiration = 30 days;` is passed to the constructor.
+- `script/DeployDataStreamsFeedWithRoleAssign.s.sol`: `uint32 maxExpiration = 30 days;` is passed to the constructor.
 
 ---
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -13,6 +13,8 @@ remappings = [
     'forge-std/=lib/forge-std/src/'
 ]
 
+# Tests to be done inside of src/ directory
+tests = 'src/tests'
 
 [rpc_endpoints]
 avalanche_fuji = "https://avalanche-fuji-c-chain-rpc.publicnode.com"

--- a/script/DeployDataStreamsFeed.s.sol
+++ b/script/DeployDataStreamsFeed.s.sol
@@ -24,6 +24,9 @@ contract DeployDataStreamsFeed is Script {
         // The number of decimals for the price data.
         uint8 decimals = 18;
 
+        // The maximum value for report expiration duration
+        uint32 maxExpiration = 30 days;
+
         // A human-readable description for the feed.
         string memory description = "My Custom ETH / USD Feed";
         
@@ -41,6 +44,7 @@ contract DeployDataStreamsFeed is Script {
             verifierProxyAddress,
             feedId,
             decimals,
+            maxExpiration,
             description
         );
         

--- a/script/DeployDataStreamsFeed.s.sol
+++ b/script/DeployDataStreamsFeed.s.sol
@@ -16,7 +16,7 @@ contract DeployDataStreamsFeed is Script {
         // =================================================================
 
         // The official Chainlink Verifier Proxy address for your target chain.
-        address verifierProxyAddress = 0x2ff010DEbC1297f19579B4246cad07bd24F2488A; // <-- TODO: Replace with official address
+        address verifierProxyAddress = 0x2bf612C65f5a4d388E687948bb2CF842FFb8aBB3; // <-- TODO: Replace with official address
 
         // The unique ID for the Data Stream you want to track (e.g., ETH/USD).
         bytes32 feedId = 0x000359843a543ee2fe414dc14c7e7920ef10f4372990b79d6361cdc0dd1ba782; // <-- TODO: Replace with the desired feed ID

--- a/script/DeployDataStreamsFeedWithRoleAssign.s.sol
+++ b/script/DeployDataStreamsFeedWithRoleAssign.s.sol
@@ -33,6 +33,9 @@ contract DeployDataStreamsFeedWithRoleAssign is Script {
         // The number of decimals for the price data.
         uint8 decimals = 18;
 
+        // The maximum value for report expiration duration
+        uint32 maxExpiration = 30 days;
+
         // A human-readable description for the feed.
         string memory description = "My Custom ETH / USD Feed";
         
@@ -51,6 +54,7 @@ contract DeployDataStreamsFeedWithRoleAssign is Script {
             verifierProxyAddress,
             feedId,
             decimals,
+            maxExpiration,
             description
         );
         

--- a/src/feed/DataStreamsFeedFactory.sol
+++ b/src/feed/DataStreamsFeedFactory.sol
@@ -59,9 +59,10 @@ contract DataStreamsFeedFactory {
     function createFeed(
         bytes32 feedId,
         uint8 decimals,
+        uint32 maxReportExpirationSeconds,
         string memory description
     ) external virtual returns (address addr) {
-        return createFeed(hex"", feedId, decimals, description, msg.sender, address(0));
+        return createFeed(hex"", feedId, decimals, maxReportExpirationSeconds, description, msg.sender, address(0));
     }
 
     /**
@@ -80,11 +81,12 @@ contract DataStreamsFeedFactory {
     function createFeed(
         bytes32 feedId,
         uint8 decimals,
+        uint32 maxReportExpirationSeconds,
         string memory description,
         address admin,
         address updater
     ) external virtual returns (address addr) {
-        return createFeed(hex"", feedId, decimals, description, admin, updater);
+        return createFeed(hex"", feedId, decimals, maxReportExpirationSeconds, description, admin, updater);
     }
 
     /**
@@ -106,13 +108,14 @@ contract DataStreamsFeedFactory {
         bytes32 userSalt,
         bytes32 feedId,
         uint8 decimals,
+        uint32 maxReportExpirationSeconds,
         string memory description,
         address admin,
         address updater
     ) public virtual returns (address feedAddress) {
         require(admin != address(0), "Admin address cannot be zero");
 
-        bytes memory bytecode = getBytecode(feedId, decimals, description);
+        bytes memory bytecode = getBytecode(feedId, decimals, maxReportExpirationSeconds, description);
         bytes32 finalSalt = keccak256(abi.encodePacked(msg.sender, userSalt, feedId, decimals, description));
 
         feedAddress = computeAddress(finalSalt, bytecode);
@@ -159,9 +162,10 @@ contract DataStreamsFeedFactory {
         bytes32 userSalt,
         bytes32 feedId,
         uint8 decimals,
+        uint32 maxReportExpirationSeconds,
         string memory description
     ) external view virtual returns (address) {
-        bytes memory bytecode = getBytecode(feedId, decimals, description);
+        bytes memory bytecode = getBytecode(feedId, decimals, maxReportExpirationSeconds, description);
         bytes32 finalSalt = keccak256(abi.encodePacked(creator, userSalt, feedId, decimals, description));
 
         return computeAddress(finalSalt, bytecode);
@@ -170,12 +174,13 @@ contract DataStreamsFeedFactory {
     function getBytecode(
         bytes32 feedId,
         uint8 decimals,
+        uint32 maxReportExpirationSeconds,
         string memory description
     ) internal view virtual returns (bytes memory) {
         return
             abi.encodePacked(
                 type(DataStreamsFeed).creationCode,
-                abi.encode(verifierProxy, feedId, decimals, description)
+                abi.encode(verifierProxy, feedId, decimals, maxReportExpirationSeconds, description)
             );
     }
 

--- a/src/test/FeedConstants.sol
+++ b/src/test/FeedConstants.sol
@@ -10,6 +10,7 @@ contract FeedConstants {
 
     uint32 internal constant ROUND_ID_FIRST = 1;
     uint80 internal constant ROUND_ID_TOO_LARGE = 2 ** 32;
+    uint32 internal constant MAX_REPORT_EXPIRATION_SECONDS = 30 days;
 
     FeedDescriptor internal ETH_USD_V2 =
         FeedDescriptor({

--- a/src/test/FeedStub.sol
+++ b/src/test/FeedStub.sol
@@ -8,8 +8,9 @@ contract FeedStub is DataStreamsFeed {
         address verifierProxy,
         bytes32 feedId,
         uint8 decimals,
+        uint32 maxReportExpirationSeconds,
         string memory description
-    ) DataStreamsFeed(verifierProxy, feedId, decimals, description) {}
+    ) DataStreamsFeed(verifierProxy, feedId, decimals, maxReportExpirationSeconds, description) {}
 
     function stubPush(int192 price, uint32 timestamp, uint32 expiresAt) public {
         TruncatedReport memory lastReport = latestReport;

--- a/src/test/feed/fork/DataStreamsFeedForkTest.t.sol
+++ b/src/test/feed/fork/DataStreamsFeedForkTest.t.sol
@@ -144,6 +144,7 @@ contract DataStreamsFeedForkTest is Test, FeedConstants, FeedDataFixture {
             ETH_MAINNET_VERIFIER_PROXY_ADDRESS,
             reportData.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 

--- a/src/test/feed/unit/DataStreamsFeedFactoryTest.t.sol
+++ b/src/test/feed/unit/DataStreamsFeedFactoryTest.t.sol
@@ -63,7 +63,7 @@ contract DataStreamsFeedFactoryTest is Test, FeedConstants, FeedDataFixture {
         );
 
         vm.expectRevert();
-        factory.createFeed(bytes32(0), 18, "Test Feed");
+        factory.createFeed(bytes32(0), 18, MAX_REPORT_EXPIRATION_SECONDS, "Test Feed");
     }
 
     function test_createFeed_revertsWhenAdminAddressIsZero() public {
@@ -75,6 +75,7 @@ contract DataStreamsFeedFactoryTest is Test, FeedConstants, FeedDataFixture {
         factory.createFeed(
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description,
             address(0),
             address(0)
@@ -90,6 +91,7 @@ contract DataStreamsFeedFactoryTest is Test, FeedConstants, FeedDataFixture {
         factory.createFeed(
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -98,6 +100,7 @@ contract DataStreamsFeedFactoryTest is Test, FeedConstants, FeedDataFixture {
         factory.createFeed(
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
     }
@@ -116,6 +119,7 @@ contract DataStreamsFeedFactoryTest is Test, FeedConstants, FeedDataFixture {
             salt1,
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description,
             address(this),
             address(0) // no updater
@@ -125,6 +129,7 @@ contract DataStreamsFeedFactoryTest is Test, FeedConstants, FeedDataFixture {
             salt2,
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description,
             address(this),
             address(0) // no updater
@@ -147,6 +152,7 @@ contract DataStreamsFeedFactoryTest is Test, FeedConstants, FeedDataFixture {
             hex"", // no user salt
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -161,6 +167,7 @@ contract DataStreamsFeedFactoryTest is Test, FeedConstants, FeedDataFixture {
         address feedAddress = factory.createFeed(
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -179,6 +186,7 @@ contract DataStreamsFeedFactoryTest is Test, FeedConstants, FeedDataFixture {
         address feedAddress = factory.createFeed(
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -215,6 +223,7 @@ contract DataStreamsFeedFactoryTest is Test, FeedConstants, FeedDataFixture {
         address feedAddress = factory.createFeed(
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description,
             fakeAdmin,
             noUpdater
@@ -253,6 +262,7 @@ contract DataStreamsFeedFactoryTest is Test, FeedConstants, FeedDataFixture {
         address feedAddress = factory.createFeed(
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description,
             fakeAdmin,
             fakeUpdater
@@ -300,6 +310,7 @@ contract DataStreamsFeedFactoryTest is Test, FeedConstants, FeedDataFixture {
             userSalt,
             feedId,
             decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             description
         );
 
@@ -307,6 +318,7 @@ contract DataStreamsFeedFactoryTest is Test, FeedConstants, FeedDataFixture {
             userSalt,
             feedId,
             decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             description,
             address(this),
             address(0) // no updater
@@ -333,12 +345,14 @@ contract DataStreamsFeedFactoryTest is Test, FeedConstants, FeedDataFixture {
             hex"", // no user salt
             feedId,
             decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             description
         );
 
         address actualAddress = factory.createFeed(
             feedId,
             decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             description,
             address(this),
             address(0) // no updater

--- a/src/test/feed/unit/DataStreamsFeedTest.t.sol
+++ b/src/test/feed/unit/DataStreamsFeedTest.t.sol
@@ -127,6 +127,8 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
         verifierStub = new VerifierStub();
     }
 
+    
+
     function test_ConstructorRevertsWhenVerifierProxyIsZeroAddress() public {
         // This test checks that the constructor of DataStreamsFeed reverts
         // when the verifier proxy address is zero.
@@ -138,6 +140,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(0),
             FeedConstants.ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
     }
@@ -151,6 +154,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             bytes32(0),
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
     }
@@ -162,6 +166,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -178,6 +183,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             FAKE_USD_8DEC_V3.feedId,
             FAKE_USD_8DEC_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             FAKE_USD_8DEC_V3.description
         );
 
@@ -193,6 +199,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -237,6 +244,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -255,6 +263,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -273,6 +282,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -300,6 +310,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -327,6 +338,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -352,6 +364,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -367,6 +380,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -383,6 +397,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -404,6 +419,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -424,6 +440,41 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
         );
     }
 
+    function test_AdminCanSetMaxExpriation() public {
+        DataStreamsFeed feed = new DataStreamsFeed(
+            address(verifierStub),
+            ETH_USD_V4.feedId,
+            ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
+            ETH_USD_V3.description
+        );
+
+        address admin = address(this);
+        address randomUser = address(0xBEEF);
+        address verifierRoleHolder = address(0xC0DE);
+
+        feed.grantRole(feed.REPORT_VERIFIER(), verifierRoleHolder);
+
+        vm.startPrank(admin);
+        feed.setMaxReportExpiration(10 days);
+        vm.stopPrank();
+        assertEq(
+            feed.maxReportExpirationSeconds(),
+            10 days,
+            "Admin should be able to update expiration"
+        );
+
+        vm.startPrank(randomUser);
+        vm.expectRevert();
+        feed.setMaxReportExpiration(5 days);
+        vm.stopPrank();
+
+        vm.startPrank(verifierRoleHolder);
+        vm.expectRevert();
+        feed.setMaxReportExpiration(5 days);
+        vm.stopPrank();
+    }
+
     function test_HasVersion() public {
         // This test checks that the DataStreamsFeed contract has a version function
         // that returns a non-empty string.
@@ -431,18 +482,20 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
         feed.version();
     }
-
+    
     function test_NotInitiallyPaused() public {
         // This test checks that the constructor of DataStreamsFeed initializes the feed in a non-paused state.
         DataStreamsFeed feed = new DataStreamsFeed(
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -458,6 +511,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -507,6 +561,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -538,6 +593,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -572,6 +628,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -601,6 +658,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -625,6 +683,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -659,6 +718,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -686,6 +746,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -722,6 +783,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -760,6 +822,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -796,6 +859,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -825,6 +889,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -854,6 +919,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -925,6 +991,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -995,6 +1062,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -1084,6 +1152,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -1156,6 +1225,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -1228,6 +1298,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -1311,6 +1382,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -1394,6 +1466,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
         FakeErc20 fakeErc20 = new FakeErc20();
@@ -1426,6 +1499,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
         FakeErc20 fakeErc20 = new FakeErc20();
@@ -1452,6 +1526,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
         FakeErc20 fakeErc20 = new FakeErc20();
@@ -1479,6 +1554,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -1642,6 +1718,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -1688,6 +1765,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -1715,6 +1793,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -1742,6 +1821,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -1769,6 +1849,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -1798,6 +1879,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -1835,6 +1917,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -1916,6 +1999,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -1979,6 +2063,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2042,6 +2127,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2084,6 +2170,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2177,6 +2264,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2229,6 +2317,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2310,6 +2399,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2391,6 +2481,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2521,6 +2612,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2573,6 +2665,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2625,6 +2718,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2701,6 +2795,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2744,6 +2839,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2787,6 +2883,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2849,6 +2946,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2901,6 +2999,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2953,6 +3052,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -2997,6 +3097,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3038,6 +3139,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3053,6 +3155,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3068,6 +3171,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3083,6 +3187,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3098,6 +3203,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3113,6 +3219,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3130,6 +3237,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3186,6 +3294,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3240,6 +3349,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3264,6 +3374,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3288,6 +3399,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3312,6 +3424,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3347,6 +3460,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3433,12 +3547,123 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
         );
     }
 
+    // Moved near other updateReport tests for coherence
+    function test_updateReport_revertsWhenReportExpirationTooFar() public {
+        DataStreamsFeed feed = new DataStreamsFeed(
+            address(verifierStub),
+            ETH_USD_V4.feedId,
+            ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
+            ETH_USD_V3.description
+        );
+
+        address verifierRoleHolder = address(0xC0DE);
+        feed.grantRole(feed.REPORT_VERIFIER(), verifierRoleHolder);
+
+        uint32 currentTime = uint32(block.timestamp);
+        uint32 maxExpiration = feed.maxReportExpirationSeconds();
+
+        // Build unverified report that expires one second beyond the allowed window
+        int192 price = int192(int256((uint256(2500) * 10 ** ETH_USD_V3.decimals)));
+        uint32 expiresTooFar = currentTime + maxExpiration + 1;
+
+        bytes memory unverified = generateReportData(
+            ETH_USD_V4.feedId,
+            currentTime,
+            currentTime,
+            expiresTooFar,
+            price,
+            true
+        );
+        bytes memory parameterPayload = abi.encode(address(0));
+        bytes memory verified = verifierStub.verify(unverified, parameterPayload);
+
+        vm.startPrank(verifierRoleHolder);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DataStreamsFeed.ReportExpirationTooFarInFuture.selector,
+                expiresTooFar,
+                currentTime + maxExpiration
+            )
+        );
+        feed.updateReport(4, verified);
+        vm.stopPrank();
+    }
+
+    // Moved near other updateReport tests for coherence
+    function test_updateReport_revertsWhenReportExpirationTooFarAfterAdminChange() public {
+        DataStreamsFeed feed = new DataStreamsFeed(
+            address(verifierStub),
+            ETH_USD_V4.feedId,
+            ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
+            ETH_USD_V3.description
+        );
+
+        // Setup verifier role
+        address verifierRoleHolder = address(0xC0DE);
+        feed.grantRole(feed.REPORT_VERIFIER(), verifierRoleHolder);
+
+        uint32 currentTime = uint32(block.timestamp);
+        uint32 newMaxExpiration = uint32(20 days);
+
+        // Admin lowers the max expiration window
+        vm.startPrank(address(this));
+        feed.setMaxReportExpiration(newMaxExpiration);
+        vm.stopPrank();
+
+        // Build a report that would have been valid under 30 days but is now invalid under 20 days
+        int192 price = int192(int256((uint256(3000) * 10 ** ETH_USD_V3.decimals)));
+        uint32 expiresTooFar = currentTime + uint32(30 days);
+
+        bytes memory unverifiedTooFar = generateReportData(
+            ETH_USD_V4.feedId,
+            currentTime,
+            currentTime,
+            expiresTooFar,
+            price,
+            true
+        );
+        bytes memory parameterPayload = abi.encode(address(0));
+        bytes memory verifiedTooFar = verifierStub.verify(unverifiedTooFar, parameterPayload);
+
+        vm.startPrank(verifierRoleHolder);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DataStreamsFeed.ReportExpirationTooFarInFuture.selector,
+                expiresTooFar,
+                currentTime + newMaxExpiration
+            )
+        );
+        feed.updateReport(4, verifiedTooFar);
+        vm.stopPrank();
+
+        // Build a report valid under the new 20-day window and accept it
+        uint32 expiresValid = currentTime + newMaxExpiration;
+        bytes memory unverifiedValid = generateReportData(
+            ETH_USD_V4.feedId,
+            currentTime,
+            currentTime,
+            expiresValid,
+            price,
+            true
+        );
+        bytes memory verifiedValid = verifierStub.verify(unverifiedValid, parameterPayload);
+
+        vm.startPrank(verifierRoleHolder);
+        feed.updateReport(4, verifiedValid);
+        vm.stopPrank();
+
+        assertEq(feed.latestRound(), 1, "Report with new valid expiration should be accepted");
+    }
+
     function test_verifyAndUpdateReport_handlesNoFeeToken() public {
         // This test checks that verifyAndUpdateReport works correctly when no fee token is provided.
         DataStreamsFeed feed = new DataStreamsFeed(
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3464,6 +3689,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3493,6 +3719,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3534,6 +3761,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3595,6 +3823,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 
@@ -3641,6 +3870,7 @@ contract DataStreamsFeedTest is Test, FeedConstants, FeedDataFixture {
             address(verifierStub),
             ETH_USD_V3.feedId,
             ETH_USD_V3.decimals,
+            MAX_REPORT_EXPIRATION_SECONDS,
             ETH_USD_V3.description
         );
 


### PR DESCRIPTION
Changes according to audit comments - are as follows:

1. Adding timestamp based default expiry on the DatastreamsFeed.sol contract and updating ROLES in AccessControlEnumerable. Along with other required fixes where its required.
2. Added unit tests for testing the newly added feature in `src/test` and especially the unit test script for feed contract in`src/test/feed/unit/DataStreamsFeedTest.t.sol`
3. Added NatSpec @dev comment to the `TruncatedReport` struct on the use of uint32 for timestamps has a long-term overflow risk ("Y2106 bug") - and it is an accepted trade-off


PS. Note that switching from `abi.encodeWithSelector`to `abi.encodeCall` and putting the arguments in a tuple was already merged in the [previous PR](https://github.com/woogieboogie-jl/chainlink-transmitter-contract/pull/1) along with other slight improvements.